### PR TITLE
Add WFGY RAG troubleshooting checklist (16-problem map)

### DIFF
--- a/README.md
+++ b/README.md
@@ -597,6 +597,8 @@ https://arxiv.org/abs/2506.18096
   - 借助大模型从一段文本中提取为结构化数据的库
 - [RAGLAB](https://github.com/fate-ubw/raglab)
   - RAGLAB是一个模块化、面向研究的开源框架,用于检索增强型生成(Retrieval-Augmented Generation, RAG)算法。它提供了6种现有RAG算法的复制,以及一个全面的评估系统,包括10个基准数据集,使得RAG算法之间的公平比较和新算法、数据集和评估指标的高效开发成为可能。
+- [WFGY 16 Problem Map](https://github.com/onestardao/WFGY/blob/main/ProblemMap/README.md)
+  - WFGY 是一个面向 RAG 系统的结构化故障排查项目,提供 16 问题清单,用于系统性分析检索增强生成 (RAG) 应用中的常见失败模式,如命中错误、引用陈旧内容、分块不合理、重排序失效、多轮记忆漂移等问题,帮助开发者快速定位问题属于检索、分块、重排、提示、缓存或评估链路。
 - [bRAG-langchain](https://github.com/bRAGAI/bRAG-langchain/)
   - 这个项目是一个全面探索检索增强型生成(Retrieval-Augmented Generation, RAG)的仓库,包含从入门到高级实现的详细教程,涵盖多查询、自定义RAG构建等内容。
   - ![](https://cdn.jsdelivr.net/gh/lizhe2004/pic-repo@master//imgs/20251013092105667.png)


### PR DESCRIPTION
Hi maintainers,

This PR adds a single documentation link under “开源工具 / 其他”:

- WFGY (RAG 16 问题故障排查清单)

It is a lightweight, framework-agnostic troubleshooting checklist for common RAG failures such as wrong retrieval hits, stale citations, reasoning drift, and multi-turn memory mismatch. The goal is to help readers quickly locate the failure layer (retrieval, chunking, reranking, prompting, cache, evaluation) before attempting fixes.

This is a docs-only change, no code changes.

Thanks.

close #8 